### PR TITLE
Removes references to Mix.env

### DIFF
--- a/lib/telemetric_events.ex
+++ b/lib/telemetric_events.ex
@@ -144,8 +144,8 @@ defmodule TelemetricEvents do
   @spec setup_handler(module()) :: :ok
   def setup_handler(module) do
     :telemetric_events
-      |> Application.get_env(:otp_app)
-      |> setup_handler(module)
+    |> Application.get_env(:otp_app)
+    |> setup_handler(module)
   end
 
   @doc """

--- a/lib/telemetric_events/logger/json_backend.ex
+++ b/lib/telemetric_events/logger/json_backend.ex
@@ -3,7 +3,6 @@ defmodule TelemetricEvents.Logger.JSONBackend do
   # A reimplementation of `Logger.Backends.Console`
 
   alias TelemetricEvents.Logger.JSONFormatter
-
   @behaviour :gen_event
 
   defstruct buffer: [],

--- a/lib/telemetric_events/logger/json_formatter.ex
+++ b/lib/telemetric_events/logger/json_formatter.ex
@@ -10,12 +10,14 @@ defmodule TelemetricEvents.Logger.JSONFormatter do
   # ```
   @spec format(atom(), any(), :calendar.datetime(), Keyword.t()) :: String.t()
   def format(level, message, timestamp, metadata) do
+    pretty = Application.get_env(:telemetric_events, :pretty, false)
+
     metadata
     |> parse_metadata()
     |> Map.merge(ensure_map(message))
     |> Map.put_new("level", level)
     |> Map.put_new("timestamp", erl_to_iso8601!(timestamp))
-    |> Jason.encode!(pretty: Mix.env() == :dev)
+    |> Jason.encode!(pretty: pretty)
     |> Kernel.<>("\n")
   rescue
     e -> "could not format with Jason: #{inspect({level, message, metadata, e})}\n"

--- a/lib/telemetric_events/logger/json_translator.ex
+++ b/lib/telemetric_events/logger/json_translator.ex
@@ -1,5 +1,5 @@
 defmodule TelemetricEvents.Logger.JSONTranslator do
-  @moduledoc false 
+  @moduledoc false
 
   # Uses Jason to encode a logged map. If using JSON logging, you must add this 
   # translator to the list of translators in the logger config. I.E. 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TelemetricEvents.MixProject do
   def project do
     [
       app: :telemetric_events,
-      version: "0.2.0",
+      version: "0.2.1",
       description:
         "Uses `:telemetry` to take events and combines logging and Prometheus metrics to process events",
       elixir: ">= 1.10.0",


### PR DESCRIPTION
Actual code change is in lib/telemetric_events/logger/json_formatter.ex, the rest is just formatting.